### PR TITLE
fixes #72: allow http-client 0.6, also release 0.2.0.10

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -1,5 +1,5 @@
 name: slack-web
-version: 0.2.0.9
+version: 0.2.0.10
 
 build-type: Simple
 cabal-version: 1.21
@@ -48,7 +48,7 @@ library
     , base >= 4.11 && < 4.13
     , containers
     , http-api-data >= 0.3 && < 0.5
-    , http-client >= 0.5 && < 0.6
+    , http-client >= 0.5 && < 0.7
     , http-client-tls >= 0.3 && < 0.4
     , servant >= 0.12 && < 0.16
     , servant-client >= 0.12 && < 0.16


### PR DESCRIPTION
I tested that code builds and the tests that we pass with this stack.yaml =>

```yaml
resolver: nightly-2019-02-02
extra-deps:
- http-client-0.6.1
```