### PR TITLE
DUX-3102: expose more validation error content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # 2.1.0.0 (2025-03-06)
 * [#138](https://github.com/MercuryTechnologies/slack-web/pull/138)
   Implement `views.publish` method and App Home tab events.
-* [#139](https://github.com/MercuryTechnologies/slack-web/pull/138)
+* [#140](https://github.com/MercuryTechnologies/slack-web/pull/140)
   Implement `reactions.add` method.
 
   Breaking change: various places in the API using emoji now use an Emoji
   newtype.
+* [#141](https://github.com/MercuryTechnologies/slack-web/pull/141)
+  Include `response_metadata` in errors.
+  This is a breaking change since it changes the type of `ResponseSlackError` and friends to add that field.
 
 # 2.0.1.0 (2025-01-09)
 * [#136](https://github.com/MercuryTechnologies/slack-web/pull/136)

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -33,6 +33,8 @@ extra-source-files:
   tests/golden/SlackView/*.golden
   tests/golden/PublishResp/*.json
   tests/golden/PublishResp/*.golden
+  tests/golden/ResponseJSON/*.json
+  tests/golden/ResponseJSON/*.golden
 
 category: Web
 
@@ -189,6 +191,7 @@ test-suite tests
       Web.Slack.ConversationSpec
       Web.Slack.ChatSpec
       Web.Slack.Files.TypesSpec
+      Web.Slack.InternalSpec
       Web.Slack.UsersConversationsSpec
       Web.Slack.Experimental.RequestVerificationSpec
       Web.Slack.Experimental.Events.TypesSpec

--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -27,6 +27,7 @@ module Web.Slack.Common (
   Message (..),
   MessageType (..),
   SlackClientError (..),
+  ResponseSlackError (..),
   SlackMessageText (..),
 ) where
 
@@ -84,13 +85,28 @@ instance NFData Message
 
 $(deriveJSON (jsonOpts "message") ''Message)
 
+-- | Contains errors that can be returned by the slack API.
+-- constrast with 'SlackClientError' which additionally
+-- contains errors which occured during the network communication.
+--
+-- Includes an Object correponding to the @response_metadata@ field.
+--
+-- @since 2.1.0.0
+data ResponseSlackError = ResponseSlackError
+  { errorText :: Text
+  , responseMetadata :: Object
+  }
+  deriving stock (Eq, Show, Generic)
+
+instance NFData ResponseSlackError
+
 -- |
 -- Errors that can be triggered by a slack request.
 data SlackClientError
   = -- | errors from the network connection
     ServantError ClientError
   | -- | errors returned by the slack API
-    SlackError Text
+    SlackError ResponseSlackError
   deriving stock (Eq, Generic, Show)
 
 instance NFData SlackClientError

--- a/tests/Web/Slack/InternalSpec.hs
+++ b/tests/Web/Slack/InternalSpec.hs
@@ -1,0 +1,20 @@
+module Web.Slack.InternalSpec where
+
+import JSONGolden
+import TestImport
+import Web.Slack.Internal
+
+-- | Parses nothing and succeeds!
+data NoJSONExpectations = NoJSONExpectations
+  deriving stock (Show)
+
+instance FromJSON NoJSONExpectations where
+  parseJSON _ = pure NoJSONExpectations
+
+spec :: Spec
+spec = describe "Common infrastructure" do
+  describe "Response parsing" do
+    -- FIXME(jadel): discards warnings for successful responses! seems like we
+    -- need to improve this API
+    oneGoldenTestDecode @(ResponseJSON NoJSONExpectations) "metadata_example"
+    oneGoldenTestDecode @(ResponseJSON NoJSONExpectations) "failed_view_publish"

--- a/tests/golden/ResponseJSON/failed_view_publish.golden
+++ b/tests/golden/ResponseJSON/failed_view_publish.golden
@@ -1,0 +1,17 @@
+ResponseJSON
+    ( Left
+        ( ResponseSlackError
+            { errorText = "invalid_arguments"
+            , responseMetadata = fromList
+                [
+                    ( "messages"
+                    , Array
+                        [ String "[ERROR] failed to match all allowed schemas [json-pointer:/view]"
+                        , String "[ERROR] must provide an object [json-pointer:/view]"
+                        , String "[ERROR] must provide an object [json-pointer:/view]"
+                        ]
+                    )
+                ]
+            }
+        )
+    )

--- a/tests/golden/ResponseJSON/failed_view_publish.json
+++ b/tests/golden/ResponseJSON/failed_view_publish.json
@@ -1,0 +1,11 @@
+{
+    "ok": false,
+    "error": "invalid_arguments",
+    "response_metadata": {
+        "messages": [
+            "[ERROR] failed to match all allowed schemas [json-pointer:/view]",
+            "[ERROR] must provide an object [json-pointer:/view]",
+            "[ERROR] must provide an object [json-pointer:/view]"
+        ]
+    }
+}

--- a/tests/golden/ResponseJSON/metadata_example.golden
+++ b/tests/golden/ResponseJSON/metadata_example.golden
@@ -1,0 +1,1 @@
+ResponseJSON ( Right NoJSONExpectations )

--- a/tests/golden/ResponseJSON/metadata_example.json
+++ b/tests/golden/ResponseJSON/metadata_example.json
@@ -1,0 +1,14 @@
+{
+    "ok": true,
+    "warnings": [
+        "missing_charset"
+    ],
+    "response_metadata": {
+        "warnings": [
+            "missing_charset"
+        ],
+        "messages": [
+            "[WARN] A Content-Type HTTP header was presented but did not declare a charset, such as a 'utf-8'"
+        ]
+    }
+}


### PR DESCRIPTION
Slack's API can return something like:

```
{
    "ok": true,
    "warnings": [
        "missing_charset"
    ],
    "response_metadata": {
        "warnings": [
            "missing_charset"
        ],
        "messages": [
            "[WARN] A Content-Type HTTP header was presented but did not declare a charset, such as a 'utf-8'"
        ]
    }
}
```

Source: https://api.slack.com/changelog/2016-09-28-response-metadata-is-on-the-way

This is helpful because they secretly use json schema on their end to validate what is sent to them but don't publish the schema (grrr), and their errors are actually quite helpful. Previously slack-web did not expose them at all.

This is a breaking change, unfortunately, but it should at least improve debugging greatly.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
