### PR TITLE
DUX-3104: expose the block kit builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 * [#141](https://github.com/MercuryTechnologies/slack-web/pull/141)
   Include `response_metadata` in errors.
   This is a breaking change since it changes the type of `ResponseSlackError` and friends to add that field.
+* [#142](https://github.com/MercuryTechnologies/slack-web/pull/142)
+  Make the block builder previously used in the test suite public as an
+  experimental module `Web.Slack.Experimental.Blocks.Builder`.
+
+  This makes the DSL for specifying messages built with blocks a bit nicer.
 
 # 2.0.1.0 (2025-01-09)
 * [#136](https://github.com/MercuryTechnologies/slack-web/pull/136)

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -132,6 +132,7 @@ library
       Web.Slack.User
       Web.Slack.UsersConversations
       Web.Slack.Experimental.Blocks
+      Web.Slack.Experimental.Blocks.Builder
       Web.Slack.Experimental.Blocks.Types
       Web.Slack.Experimental.Events.Types
       Web.Slack.Experimental.Views

--- a/src/Web/Slack/Experimental/Blocks/Builder.hs
+++ b/src/Web/Slack/Experimental/Blocks/Builder.hs
@@ -1,0 +1,105 @@
+-- | A builder for Slack blocks
+--
+-- @since 2.1.0.0
+module Web.Slack.Experimental.Blocks.Builder where
+
+import Control.Monad.Writer.Strict
+import Web.Slack.Experimental.Blocks.Types (SlackAccessory (..), SlackAction, SlackActionList, SlackBlock (..), SlackBlockId, SlackContent, SlackContext (..), SlackPlainTextOnly (..), SlackSection (..), SlackText, slackSectionWithText)
+import Web.Slack.Prelude
+
+type BlockBuilder = WriterT [SlackBlock]
+
+-- | Runs a block builder, yielding a result
+runBlockBuilder :: (Monad m) => BlockBuilder m () -> m [SlackBlock]
+runBlockBuilder = execWriterT
+
+-- | Header block.
+--
+-- The text is max 150 characters long.
+--
+-- <https://api.slack.com/reference/block-kit/blocks#header>
+--
+-- @since 2.1.0.0
+headerBlock :: (Monad m) => SlackText -> BlockBuilder m ()
+headerBlock = tell . pure . SlackBlockHeader . SlackPlainTextOnly
+
+-- | Section block. Similar in concept to a p or div tag in HTML.
+--
+-- <https://api.slack.com/reference/block-kit/blocks#section>
+--
+-- @since 2.1.0.0
+sectionBlock :: (Monad m) => SlackText -> BlockBuilder m ()
+sectionBlock = tell . pure . SlackBlockSection . slackSectionWithText
+
+-- | Section block. Similar in concept to a p or div tag in HTML.
+--
+-- <https://api.slack.com/reference/block-kit/blocks#section>
+--
+-- @since 2.1.0.0
+sectionBlockWithFields :: (Monad m) => SlackText -> [SlackText] -> BlockBuilder m ()
+sectionBlockWithFields text fields =
+  tell
+    $ pure
+    $ SlackBlockSection
+    $ SlackSection
+      { slackSectionText = Just text
+      , slackSectionBlockId = Nothing
+      , slackSectionFields = Just fields
+      , slackSectionAccessory = Nothing
+      }
+
+-- | Section block. Similar in concept to a p or div tag in HTML.
+--
+-- <https://api.slack.com/reference/block-kit/blocks#section>
+--
+-- @since 2.1.0.0
+sectionBlockWithAccessory ::
+  (Monad m) =>
+  SlackText ->
+  SlackAction ->
+  BlockBuilder m ()
+sectionBlockWithAccessory t b =
+  tell
+    $ pure
+    $ SlackBlockSection
+      SlackSection
+        { slackSectionText = Just t
+        , slackSectionBlockId = Nothing
+        , slackSectionFields = Nothing
+        , slackSectionAccessory = Just $ SlackButtonAccessory b
+        }
+
+-- | Horizontal line. Similar to an html @hr@ tag.
+--
+-- <https://api.slack.com/reference/block-kit/blocks#divider>
+--
+-- @since 2.1.0.0
+dividerBlock :: (Monad m) => BlockBuilder m ()
+dividerBlock = tell . pure $ SlackBlockDivider
+
+-- | Context block: smaller, grey, text, and rendered inline. Like a @span@ in HTML.
+--
+-- <https://api.slack.com/reference/block-kit/blocks#context>
+contextBlock :: (Monad m) => [SlackContent] -> BlockBuilder m ()
+contextBlock = tell . pure . SlackBlockContext . SlackContext
+
+-- | Inline container for interactive actions.
+--
+-- <https://api.slack.com/reference/block-kit/blocks#actions>
+actionsBlock ::
+  (Monad m) =>
+  Maybe SlackBlockId ->
+  SlackActionList ->
+  BlockBuilder m ()
+actionsBlock a b = tell . pure $ SlackBlockActions a b
+
+-- | This is used for testing purposes so that you can paste these into the
+-- Block Kit builder and have the expected format:
+--
+-- <https://app.slack.com/block-kit-builder>
+--
+-- @since 2.1.0.0
+newtype BlockKitBuilderMessage = BlockKitBuilderMessage {blocks :: [SlackBlock]}
+
+instance ToJSON BlockKitBuilderMessage where
+  toJSON BlockKitBuilderMessage {blocks} = object [("blocks", toJSON blocks)]

--- a/src/Web/Slack/Experimental/Blocks/Types.hs
+++ b/src/Web/Slack/Experimental/Blocks/Types.hs
@@ -398,13 +398,30 @@ slackSectionWithText t =
     }
 
 data SlackBlock
-  = SlackBlockSection SlackSection
+  = -- | Section block. Similar in concept to a @p@ or @div@ tag in HTML.
+    --
+    -- <https://api.slack.com/reference/block-kit/blocks#section>
+    SlackBlockSection SlackSection
   | SlackBlockImage SlackImage
-  | SlackBlockContext SlackContext
-  | SlackBlockDivider
+  | -- | Context block: smaller, grey, text, and rendered inline. Like a @span@ in HTML.
+    --
+    -- <https://api.slack.com/reference/block-kit/blocks#context>
+    SlackBlockContext SlackContext
+  | -- | Horizontal line. Similar to an html @hr@ tag.
+    --
+    -- <https://api.slack.com/reference/block-kit/blocks#divider>
+    SlackBlockDivider
   | SlackBlockRichText RichText
-  | SlackBlockActions (Maybe SlackBlockId) SlackActionList -- 1 to 5 elements
-  | SlackBlockHeader SlackPlainTextOnly -- max length 150
+  | -- | Inline container for interactive actions.
+    --
+    -- <https://api.slack.com/reference/block-kit/blocks#actions>
+    SlackBlockActions (Maybe SlackBlockId) SlackActionList -- 1 to 5 elements
+  | -- | Header block.
+    --
+    -- The text is max 150 characters long.
+    --
+    -- <https://api.slack.com/reference/block-kit/blocks#header>
+    SlackBlockHeader SlackPlainTextOnly
   | SlackBlockOther Object
   deriving stock (Eq)
 

--- a/tests/Web/Slack/Experimental/BlocksSpec.hs
+++ b/tests/Web/Slack/Experimental/BlocksSpec.hs
@@ -1,59 +1,11 @@
 module Web.Slack.Experimental.BlocksSpec where
 
-import Control.Monad.Writer.Strict
 import Data.StringVariants (mkNonEmptyText)
 import JSONGolden (oneGoldenTestEncode)
 import TestImport
 import Web.Slack.Experimental.Blocks
+import Web.Slack.Experimental.Blocks.Builder (BlockKitBuilderMessage (..), actionsBlock, contextBlock, dividerBlock, headerBlock, runBlockBuilder, sectionBlock, sectionBlockWithAccessory, sectionBlockWithFields)
 import Web.Slack.Experimental.Blocks.Types
-
--- FIXME(jadel, violet): These builder things should probably be put into a
--- module to make them available, but that's later work
-
-headerBlock :: SlackText -> WriterT [SlackBlock] Identity ()
-headerBlock = tell . pure . SlackBlockHeader . SlackPlainTextOnly
-
-sectionBlock :: SlackText -> WriterT [SlackBlock] Identity ()
-sectionBlock = tell . pure . SlackBlockSection . slackSectionWithText
-
-sectionBlockWithFields :: SlackText -> [SlackText] -> WriterT [SlackBlock] Identity ()
-sectionBlockWithFields text fields =
-  tell
-    $ pure
-    $ SlackBlockSection
-    $ SlackSection
-      { slackSectionText = Just text
-      , slackSectionBlockId = Nothing
-      , slackSectionFields = Just fields
-      , slackSectionAccessory = Nothing
-      }
-
-sectionBlockWithAccessory ::
-  SlackText ->
-  SlackAction ->
-  WriterT [SlackBlock] Identity ()
-sectionBlockWithAccessory t b =
-  tell
-    $ pure
-    $ SlackBlockSection
-      SlackSection
-        { slackSectionText = Just t
-        , slackSectionBlockId = Nothing
-        , slackSectionFields = Nothing
-        , slackSectionAccessory = Just $ SlackButtonAccessory b
-        }
-
-dividerBlock :: WriterT [SlackBlock] Identity ()
-dividerBlock = tell . pure $ SlackBlockDivider
-
-contextBlock :: [SlackContent] -> WriterT [SlackBlock] Identity ()
-contextBlock = tell . pure . SlackBlockContext . SlackContext
-
-actionsBlock ::
-  Maybe SlackBlockId ->
-  SlackActionList ->
-  WriterT [SlackBlock] Identity ()
-actionsBlock a b = tell . pure $ SlackBlockActions a b
 
 slackActionDoNothing :: SlackActionId
 slackActionDoNothing = SlackActionId . fromJust . mkNonEmptyText $ "doNothing"
@@ -67,7 +19,8 @@ slackActionDoNothing3 = SlackActionId . fromJust . mkNonEmptyText $ "doNothing3"
 slackShowBlockFormat :: BlockKitBuilderMessage
 slackShowBlockFormat =
   BlockKitBuilderMessage
-    $ execWriter
+    $ runIdentity
+    . runBlockBuilder
     $ do
       headerBlock ("Blah: " <> list ["a", "b", "c"])
       dividerBlock
@@ -104,14 +57,6 @@ slackShowBlockFormat =
     textMessage = message @Text
     list x = textMessage (intercalate ", " x)
     google = OptionalSetting . mkNonEmptyText @3000 $ "https://google.com"
-
--- | This is used so that we can paste the output of these tests directly into
--- the block kit builder:
--- <https://app.slack.com/block-kit-builder>
-newtype BlockKitBuilderMessage = BlockKitBuilderMessage {blocks :: [SlackBlock]}
-
-instance ToJSON BlockKitBuilderMessage where
-  toJSON BlockKitBuilderMessage {blocks} = object [("blocks", toJSON blocks)]
 
 spec :: Spec
 spec = describe "Slack block builder" do


### PR DESCRIPTION
This was used in tests and is quite useful for relatively ergonomically writing block kit stuff.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
