### PR TITLE
Add bot profile field to messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   experimental module `Web.Slack.Experimental.Blocks.Builder`.
 
   This makes the DSL for specifying messages built with blocks a bit nicer.
+* [#143](https://github.com/MercuryTechnologies/slack-web/pull/143)
+  Add the `bot_profile` field to messages.
 
 # 2.0.1.0 (2025-01-09)
 * [#136](https://github.com/MercuryTechnologies/slack-web/pull/136)

--- a/tests/golden/SlackWebhookEvent/botMessage.golden
+++ b/tests/golden/SlackWebhookEvent/botMessage.golden
@@ -37,6 +37,15 @@ EventEventCallback
                 , threadTs = Just "1664216109.798919"
                 , appId = Just "A0442TUPHGR"
                 , botId = Just "B0439P161B9"
+                , botProfile = Just
+                    ( BotProfile
+                        { id = "B0439P161B9"
+                        , name = "Slacklinker dev"
+                        , appId = "A0442TUPHGR"
+                        , teamId = TeamId
+                            { unTeamId = "T043DB835ML" }
+                        }
+                    )
                 , attachments = Nothing
                 }
             )

--- a/tests/golden/SlackWebhookEvent/circleci.golden
+++ b/tests/golden/SlackWebhookEvent/circleci.golden
@@ -50,6 +50,15 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Just "A56789123"
                 , botId = Just "B01234687"
+                , botProfile = Just
+                    ( BotProfile
+                        { id = "B01234687"
+                        , name = "CircleCI integration"
+                        , appId = "A56789123"
+                        , teamId = TeamId
+                            { unTeamId = "T0123456789" }
+                        }
+                    )
                 , attachments = Nothing
                 }
             )

--- a/tests/golden/SlackWebhookEvent/email_message.golden
+++ b/tests/golden/SlackWebhookEvent/email_message.golden
@@ -37,6 +37,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Just "B012346789"
+                , botProfile = Nothing
                 , attachments = Nothing
                 }
             )

--- a/tests/golden/SlackWebhookEvent/forwarded_message.golden
+++ b/tests/golden/SlackWebhookEvent/forwarded_message.golden
@@ -22,6 +22,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , botProfile = Nothing
                 , attachments = Just
                     [ MessageAttachment
                         { decoded = Just

--- a/tests/golden/SlackWebhookEvent/github_notification.golden
+++ b/tests/golden/SlackWebhookEvent/github_notification.golden
@@ -22,6 +22,15 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Just "A01BP7R4KNY"
                 , botId = Just "B07LDR01Z63"
+                , botProfile = Just
+                    ( BotProfile
+                        { id = "B07LDR01Z63"
+                        , name = "GitHub"
+                        , appId = "A01BP7R4KNY"
+                        , teamId = TeamId
+                            { unTeamId = "T043DB835ML" }
+                        }
+                    )
                 , attachments = Just
                     [ MessageAttachment
                         { decoded = Just

--- a/tests/golden/SlackWebhookEvent/github_notification_ts_string.golden
+++ b/tests/golden/SlackWebhookEvent/github_notification_ts_string.golden
@@ -22,6 +22,15 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Just "A01BP7R4KNY"
                 , botId = Just "B07LDR01Z63"
+                , botProfile = Just
+                    ( BotProfile
+                        { id = "B07LDR01Z63"
+                        , name = "GitHub"
+                        , appId = "A01BP7R4KNY"
+                        , teamId = TeamId
+                            { unTeamId = "T043DB835ML" }
+                        }
+                    )
                 , attachments = Just
                     [ MessageAttachment
                         { decoded = Just

--- a/tests/golden/SlackWebhookEvent/github_with_link.golden
+++ b/tests/golden/SlackWebhookEvent/github_with_link.golden
@@ -22,6 +22,15 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Just "A01BP7R4KNY"
                 , botId = Just "B07LDR01Z63"
+                , botProfile = Just
+                    ( BotProfile
+                        { id = "B07LDR01Z63"
+                        , name = "GitHub"
+                        , appId = "A01BP7R4KNY"
+                        , teamId = TeamId
+                            { unTeamId = "T043DB835ML" }
+                        }
+                    )
                 , attachments = Just
                     [ MessageAttachment
                         { decoded = Just

--- a/tests/golden/SlackWebhookEvent/link.golden
+++ b/tests/golden/SlackWebhookEvent/link.golden
@@ -41,6 +41,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , botProfile = Nothing
                 , attachments = Nothing
                 }
             )

--- a/tests/golden/SlackWebhookEvent/messageExample.golden
+++ b/tests/golden/SlackWebhookEvent/messageExample.golden
@@ -37,6 +37,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , botProfile = Nothing
                 , attachments = Nothing
                 }
             )

--- a/tests/golden/SlackWebhookEvent/messageIm.golden
+++ b/tests/golden/SlackWebhookEvent/messageIm.golden
@@ -37,6 +37,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , botProfile = Nothing
                 , attachments = Nothing
                 }
             )

--- a/tests/golden/SlackWebhookEvent/message_file_share.golden
+++ b/tests/golden/SlackWebhookEvent/message_file_share.golden
@@ -52,6 +52,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , botProfile = Nothing
                 , attachments = Nothing
                 }
             )

--- a/tests/golden/SlackWebhookEvent/message_file_share_slack_connect.golden
+++ b/tests/golden/SlackWebhookEvent/message_file_share_slack_connect.golden
@@ -27,6 +27,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , botProfile = Nothing
                 , attachments = Nothing
                 }
             )

--- a/tests/golden/SlackWebhookEvent/message_rich_text.golden
+++ b/tests/golden/SlackWebhookEvent/message_rich_text.golden
@@ -82,6 +82,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , botProfile = Nothing
                 , attachments = Nothing
                 }
             )

--- a/tests/golden/SlackWebhookEvent/non_spec_attachment.golden
+++ b/tests/golden/SlackWebhookEvent/non_spec_attachment.golden
@@ -22,6 +22,15 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Just "A01BP7R4KNY"
                 , botId = Just "B07LDR01Z63"
+                , botProfile = Just
+                    ( BotProfile
+                        { id = "B07LDR01Z63"
+                        , name = "GitHub"
+                        , appId = "A01BP7R4KNY"
+                        , teamId = TeamId
+                            { unTeamId = "T043DB835ML" }
+                        }
+                    )
                 , attachments = Just
                     [ MessageAttachment
                         { decoded = Just

--- a/tests/golden/SlackWebhookEvent/share_with_message.golden
+++ b/tests/golden/SlackWebhookEvent/share_with_message.golden
@@ -37,6 +37,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , botProfile = Nothing
                 , attachments = Just
                     [ MessageAttachment
                         { decoded = Just

--- a/tests/golden/SlackWebhookEvent/share_without_message.golden
+++ b/tests/golden/SlackWebhookEvent/share_without_message.golden
@@ -22,6 +22,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , botProfile = Nothing
                 , attachments = Just
                     [ MessageAttachment
                         { decoded = Just

--- a/tests/golden/SlackWebhookEvent/slackbotIm.golden
+++ b/tests/golden/SlackWebhookEvent/slackbotIm.golden
@@ -46,6 +46,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , botProfile = Nothing
                 , attachments = Nothing
                 }
             )


### PR DESCRIPTION
This can be useful for ignoring messages from certain bots by name if you don't want to hardcode their App Id.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
