### PR TITLE
Changelog: fix the heading for 2.2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.1.1.0
+# 2.2.0.0 (2025-03-21)
 * [#145](https://github.com/MercuryTechnologies/slack-web/pull/145)
   Implement `conversations.info` API method.
 


### PR DESCRIPTION
This was just a mistake, 2.1.1.0 never happened since we needed a breaking change.

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
