### PR TITLE
Add limit, cursor, and pagination support to conversationsMembers

### DIFF
--- a/src/Web/Slack/Conversation.hs
+++ b/src/Web/Slack/Conversation.hs
@@ -45,6 +45,7 @@ module Web.Slack.Conversation (
   conversationsJoin,
   conversationsJoin_,
   MembersReq (..),
+  mkMembersReq,
   MembersRsp (..),
   conversationsMembers,
   conversationsMembers_,
@@ -486,13 +487,34 @@ $(deriveJSON (jsonOpts "infoRsp") ''InfoRsp)
 -- @since 2.2.1.0
 data MembersReq = MembersReq
   { membersReqChannel :: ConversationId
+  , membersReqCursor :: Maybe Cursor
+  , membersReqLimit :: Maybe Int
   }
   deriving stock (Eq, Show, Generic)
+
+instance NFData MembersReq
 
 $(deriveFromJSON (jsonOpts "membersReq") ''MembersReq)
 
 instance ToForm MembersReq where
-  toForm = genericToForm (formOpts "membersReq")
+  toForm MembersReq {..} =
+    [("channel", toQueryParam membersReqChannel)]
+      <> toQueryParamIfJust "cursor" membersReqCursor
+      <> toQueryParamIfJust "limit" membersReqLimit
+
+-- | Smart constructor for 'MembersReq' with defaults.
+--
+-- @since 2.2.1.0
+mkMembersReq :: ConversationId -> MembersReq
+mkMembersReq channel =
+  MembersReq
+    { membersReqChannel = channel
+    , membersReqCursor = Nothing
+    , membersReqLimit = Nothing
+    }
+
+instance PagedRequest MembersReq where
+  setCursor c r = r {membersReqCursor = c}
 
 -- | @conversation.members@ response
 --
@@ -501,10 +523,18 @@ instance ToForm MembersReq where
 -- @since 2.2.1.0
 data MembersRsp = MembersRsp
   { membersRspMembers :: [UserId]
+  , membersRspResponseMetadata :: Maybe ResponseMetadata
   }
   deriving stock (Eq, Show, Generic)
 
+instance NFData MembersRsp
+
 $(deriveFromJSON (jsonOpts "membersRsp") ''MembersRsp)
+
+instance PagedResponse MembersRsp where
+  type ResponseObject MembersRsp = UserId
+  getResponseData MembersRsp {membersRspMembers} = membersRspMembers
+  getResponseMetadata MembersRsp {membersRspResponseMetadata} = membersRspResponseMetadata
 
 -- | FIXME(jadel): move the rest of the Conversations API into here since the old "shoving all the API in one spot" is soft deprecated.
 -- @since 2.2.0.0

--- a/tests/Web/Slack/ConversationSpec.hs
+++ b/tests/Web/Slack/ConversationSpec.hs
@@ -116,6 +116,7 @@ spec = describe "ToJSON and FromJSON for Conversation" $ do
     mapM_ (oneGoldenTestDecode @Conversation) ["shared_channel"]
     mapM_ (oneGoldenTestDecode @InfoRsp) ["general"]
     mapM_ (oneGoldenTestDecode @JoinRsp) ["test"]
+    mapM_ (oneGoldenTestDecode @MembersReq) ["with_limit"]
     mapM_ (oneGoldenTestDecode @MembersRsp) ["test"]
 
   it "errors accurately if no variant matches" $ do

--- a/tests/golden/MembersReq/with_limit.golden
+++ b/tests/golden/MembersReq/with_limit.golden
@@ -1,0 +1,9 @@
+MembersReq
+    { membersReqChannel = ConversationId
+        { unConversationId = "C1234567890" }
+    , membersReqCursor = Just
+        ( Cursor
+            { unCursor = "dXNlcjpVMDYxRjdBVVI=" }
+        )
+    , membersReqLimit = Just 200
+    }

--- a/tests/golden/MembersReq/with_limit.json
+++ b/tests/golden/MembersReq/with_limit.json
@@ -1,0 +1,5 @@
+{
+    "channel": "C1234567890",
+    "cursor": "dXNlcjpVMDYxRjdBVVI=",
+    "limit": 200
+}

--- a/tests/golden/MembersRsp/test.golden
+++ b/tests/golden/MembersRsp/test.golden
@@ -7,5 +7,12 @@ MembersRsp
         , UserId
             { unUserId = "W012A3CDE" }
         ]
+    , membersRspResponseMetadata = Just
+        ( ResponseMetadata
+            { responseMetadataNextCursor = Just
+                ( Cursor
+                    { unCursor = "e3VzZXJfaWQ6IFcxMjM0NTY3fQ==" }
+                )
+            }
+        )
     }
-


### PR DESCRIPTION
## Summary

Ok this should be my last PR here — I just needed to add limit/cursor fields to the API!

- Adds optional `limit` and `cursor` fields to `MembersReq` for controlling page size and cursor-based pagination
- Adds `ResponseMetadata` to `MembersRsp` to expose the next cursor
- Implements `PagedRequest` and `PagedResponse` instances for use with the existing pager infrastructure
- Adds `mkMembersReq` smart constructor with defaults
- Updates golden test to include the response metadata

## Motivation

The previous `MembersReq` only accepted a channel ID, so Slack's default page size (100) was always used and there was no way to paginate through larger channels. This change enables callers to request up to 1000 members per page and iterate through all members using cursors.

## Test plan

- [x] `cabal build` passes
- [x] All 83 existing tests pass
- [x] Golden test updated for new `MembersRsp` shape

Made with [Cursor](https://cursor.com)